### PR TITLE
improve formatting of full_description.txt

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,6 +1,7 @@
-A modern git client for android
+PuppyGit Pro is a modern git client for Android. Open Source, no Ads and free to use.
 
-features：
+Features：
+
 - pull/push when enter/exit specified apps
 - tasker supported via http service
 - fetch/merge/pull/push/sync/checkout/reset


### PR DESCRIPTION
This improves formatting of the fastlane full description, to also render fine as Markdown (looking much better then; supported e.g. at IzzyOnDroid) – while still staying compatible with places not supporting Markdown. It's basically "upstreaming" the modifications we've made at IzzyOnDroid locally – hope you like and accept this!