### PR TITLE
feat: Progress notification auto dismiss

### DIFF
--- a/app/src/main/java/com/catpuppyapp/puppygit/notification/base/NotifyBase.kt
+++ b/app/src/main/java/com/catpuppyapp/puppygit/notification/base/NotifyBase.kt
@@ -36,6 +36,11 @@ abstract class NotifyBase(
     abstract val notifyId:Int
 
     /**
+     * if > 0, notification will auto dismiss after this milliseconds
+     */
+    var timeoutAfterMs:Long = 0
+
+    /**
      * 用来避免重复执行init出错
      */
     private val inited:MutableState<Boolean> = mutableStateOf(false)
@@ -82,6 +87,10 @@ abstract class NotifyBase(
         val context = context ?: appContext
 
         val builder = getNotificationBuilder(context, title, message, pendingIntent) // 点击后自动消失
+
+        if (timeoutAfterMs > 0) {
+            builder.setTimeoutAfter(timeoutAfterMs)
+        }
 
         NotificationManagerCompat.from(context).apply {
             if (ActivityCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {

--- a/app/src/main/java/com/catpuppyapp/puppygit/screen/content/homescreen/innerpage/AutomationInnerPage.kt
+++ b/app/src/main/java/com/catpuppyapp/puppygit/screen/content/homescreen/innerpage/AutomationInnerPage.kt
@@ -140,6 +140,7 @@ fun AutomationInnerPage(
     val appListLoading = rememberSaveable { mutableStateOf(SharedState.defaultLoadingValue) }
 
     val progressNotify = rememberSaveable { mutableStateOf(settingsState.value.automation.showNotifyWhenProgress) }
+    val progressNotifyAutoDismiss = rememberSaveable { mutableStateOf(settingsState.value.automation.progressNotifyAutoDismiss) }
 //    val errNotify = rememberSaveable { mutableStateOf(settingsState.value.automation.showNotifyWhenErr) }
 //    val successNotify = rememberSaveable { mutableStateOf(settingsState.value.automation.showNotifyWhenSuccess) }
 
@@ -637,6 +638,30 @@ fun AutomationInnerPage(
                 )
 
 
+            }
+
+            item {
+                SettingsContentSwitcher(
+                    left = {
+                        Text(stringResource(R.string.progress_notification_auto_dismiss), fontSize = itemFontSize)
+                        Text(stringResource(R.string.progress_notification_auto_dismiss_desc), fontSize = itemDescFontSize, fontWeight = FontWeight.Light)
+                    },
+                    right = {
+                        Switch(
+                            checked = progressNotifyAutoDismiss.value,
+                            onCheckedChange = null
+                        )
+                    },
+                    onClick = {
+                        val newValue = !progressNotifyAutoDismiss.value
+
+                        //save
+                        progressNotifyAutoDismiss.value = newValue
+                        SettingsUtil.update {
+                            it.automation.progressNotifyAutoDismiss = newValue
+                        }
+                    }
+                )
             }
 
             // pull interval

--- a/app/src/main/java/com/catpuppyapp/puppygit/service/AutomationService.kt
+++ b/app/src/main/java/com/catpuppyapp/puppygit/service/AutomationService.kt
@@ -113,7 +113,7 @@ class AutomationService: BaseAccessibilityService() {
         ) {
             if(AppModel.devModeOn) {
                 MyLog.d(TAG, "#pullRepoList: generate notifyers for ${repoList.size} repos")
-                val notify = createNotify(NotifyUtil.genId())
+                val notify = createNotify(NotifyUtil.genId(), settings)
                 notify.sendNormalNotification("auto pull", currentPackageName)
             }
 

--- a/app/src/main/java/com/catpuppyapp/puppygit/service/AutomationService.kt
+++ b/app/src/main/java/com/catpuppyapp/puppygit/service/AutomationService.kt
@@ -77,8 +77,12 @@ class AutomationService: BaseAccessibilityService() {
             AutoSrvCache.setCurPackageName("")
         }
 
-        private fun createNotify(notifyId:Int):ServiceNotify {
-            return ServiceNotify(AutomationServiceExecuteNotify.create(notifyId))
+        private fun createNotify(notifyId:Int, settings: AppSettings):ServiceNotify {
+            val notify = AutomationServiceExecuteNotify.create(notifyId)
+            if (settings.automation.progressNotifyAutoDismiss) {
+                notify.timeoutAfterMs = 5000
+            }
+            return ServiceNotify(notify)
         }
 
 
@@ -115,7 +119,7 @@ class AutomationService: BaseAccessibilityService() {
 
             repoList.forEachBetter {
                 //notify
-                val serviceNotify = createNotify(NotifyUtil.genId())
+                val serviceNotify = createNotify(NotifyUtil.genId(), settings)
                 NotifySenderMap.set(
                     NotifySenderMap.genKey(it.id, sessionId),
                     NotificationSender(
@@ -147,13 +151,13 @@ class AutomationService: BaseAccessibilityService() {
 
             if(AppModel.devModeOn) {
                 MyLog.d(TAG, "#pushRepoList: generate notifyers for ${repoList.size} repos")
-                val notify = createNotify(NotifyUtil.genId())
+                val notify = createNotify(NotifyUtil.genId(), settings)
                 notify.sendNormalNotification("auto push", "leave: $targetPackageName\nnow: $currentPackageName")
             }
 
             repoList.forEachBetter {
                 //notify
-                val serviceNotify = createNotify(NotifyUtil.genId())
+                val serviceNotify = createNotify(NotifyUtil.genId(), settings)
                 NotifySenderMap.set(
                     NotifySenderMap.genKey(it.id, sessionId),
                     NotificationSender(

--- a/app/src/main/java/com/catpuppyapp/puppygit/settings/AutomationSettings.kt
+++ b/app/src/main/java/com/catpuppyapp/puppygit/settings/AutomationSettings.kt
@@ -29,6 +29,12 @@ data class AutomationSettings (
      */
     var showNotifyWhenProgress:Boolean = true,
 
+    /**
+     * auto dismiss progress notification after a timeout
+     * 进度通知自动消除，开启后通知会在一段时间后自动消失
+     */
+    var progressNotifyAutoDismiss:Boolean = false,
+
 
     /**
      * 在一段时间间隔内重复进入app只有第一次才会执行pull

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1161,6 +1161,8 @@
     <string name="list_of_ips">ip列表</string>
     <string name="api">Api</string>
     <string name="progress_notification">进度通知</string>
+    <string name="progress_notification_auto_dismiss">进度通知自动消除</string>
+    <string name="progress_notification_auto_dismiss_desc">通知作为提醒，但不保留在通知栏里</string>
     <string name="do_you_want_to_edit_the_file_or_import_it">你想编辑文件还是导入文件？</string>
     <string name="ask">询问</string>
     <string name="accessibility_service_description">用于实现在 进入/离开 指定应用时自动 拉取/推送</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1290,5 +1290,5 @@
     <string name="activity_not_found">未找到可处理此操作的应用</string>
     <string name="share">分享</string>
     <string name="line_break">换行符</string>
-
 </resources>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1184,6 +1184,8 @@
     <string name="list_of_ips">List of ips</string>
     <string name="api">Api</string>
     <string name="progress_notification">Progress Notification</string>
+    <string name="progress_notification_auto_dismiss">Notification Auto Dismiss</string>
+    <string name="progress_notification_auto_dismiss_desc">Progress Notification as a reminder but doesn't stay in the notification bar</string>
     <string name="do_you_want_to_edit_the_file_or_import_it">Do you want to edit the file or import it?</string>
     <string name="ask">Ask</string>
     <string name="accessibility_service_description">For auto pull/push when enter/exit specified apps</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1185,7 +1185,7 @@
     <string name="api">Api</string>
     <string name="progress_notification">Progress Notification</string>
     <string name="progress_notification_auto_dismiss">Notification Auto Dismiss</string>
-    <string name="progress_notification_auto_dismiss_desc">Progress Notification as a reminder but doesn't stay in the notification bar</string>
+    <string name="progress_notification_auto_dismiss_desc">Progress Notification as a reminder but doesn\'t stay in the notification bar</string>
     <string name="do_you_want_to_edit_the_file_or_import_it">Do you want to edit the file or import it?</string>
     <string name="ask">Ask</string>
     <string name="accessibility_service_description">For auto pull/push when enter/exit specified apps</string>


### PR DESCRIPTION
实现了一个进度通知自动消除的功能。通知仍然显示，但不会再保留在通知栏里

这个功能默认关闭，可以选择打开

原来的进度通知会堆积在通知栏，积压很多，因此需要这个功能

如图
<img width="1440" height="3082" alt="Screenshot_20260328-160819_小狗Git" src="https://github.com/user-attachments/assets/93fc6fa5-86da-4bb2-b7a0-261cf1c9c8c4" />
